### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,19 +1,19 @@
-Glue           KEYWORD1
+Glue	KEYWORD1
 
-create	       KEYWORD2
+create	KEYWORD2
 
-add            KEYWORD2
+add	KEYWORD2
 
-getPackage     KEYWORD2
-debug	       KEYWORD2
-length	       KEYWORD2
+getPackage	KEYWORD2
+debug	KEYWORD2
+length	KEYWORD2
 
 setStartByte	KEYWORD2
-setEndByte  	KEYWORD2
+setEndByte	KEYWORD2
 setDelimiter	KEYWORD2
 
 getStartByte	KEYWORD2
-getEndByte  	KEYWORD2
+getEndByte	KEYWORD2
 getDelimiter	KEYWORD2
 
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords